### PR TITLE
build: ci/cd + automated dist updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: ci
+on: push
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+    name: Node 16
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: yarn install
+        run: yarn install
+
+      - name: yarn install
+        run: yarn build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
           node-version: 16
           cache: 'yarn'
 
-      - name: yarn install
-        run: yarn install
+      - run: yarn install
 
-      - name: yarn install
-        run: yarn build
+      - run: yarn build

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   update:
+    permissions:
+      contents: write
     runs-on: ubuntu-22.04
     name: Commit Dist
 

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,0 +1,28 @@
+name: ci
+on: push
+
+jobs:
+  update:
+    runs-on: ubuntu-22.04
+    name: Commit Dist
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'yarn'
+
+      - name: yarn install
+        run: yarn install
+
+      - name: yarn install
+        run: yarn build
+
+      - name: Commit updated dist
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Update dist
+          file_pattern: dist/

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -20,11 +20,9 @@ jobs:
           node-version: 16
           cache: 'yarn'
 
-      - name: yarn install
-        run: yarn install
+      - run: yarn install
 
-      - name: yarn install
-        run: yarn build
+      - run: yarn build
 
       - name: Commit updated dist
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -1,5 +1,8 @@
-name: ci
-on: push
+name: dist
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   update:

--- a/README.md
+++ b/README.md
@@ -44,11 +44,6 @@ Store that in GitHub Secrets to securely pass to the action.
 ```
 
 ## Development
-Make `ncc` available in your build environment:
-```shell
-npm i -g @vercel/ncc
-```
-    
 Install package dependencies:
 ```shell
 yarn install

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "scripts": {
     "build": "ncc build index.js --source-map --license licenses.txt"
+  },
+  "devDependencies": {
+    "@vercel/ncc": "^0.36.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -163,6 +163,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.9.tgz#02d013de7058cea16d36168ef2fc653464cfbad4"
   integrity sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==
 
+"@vercel/ncc@^0.36.1":
+  version "0.36.1"
+  resolved "https://registry.yarnpkg.com/@vercel/ncc/-/ncc-0.36.1.tgz#d4c01fdbbe909d128d1bf11c7f8b5431654c5b95"
+  integrity sha512-S4cL7Taa9yb5qbv+6wLgiKVZ03Qfkc4jGRuiUQMQ8HGBD5pcNRnHeYM33zBvJE4/zJGjJJ8GScB+WmTsn9mORw==
+
 JSONStream@^1.3.4, JSONStream@^1.3.5:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"


### PR DESCRIPTION
* This will automatically commit back to the repo the compiled /dist files. So we don't have to do that as part of our PRs.
* Add NCC so we can track version. Otherwise the global install changes the dist generation format every once in awhile