### PR TITLE
build: version 1.5.0 tagged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.5.0 (March 16, 2026)
+ * Move action to node24.
+ * Upgrade dependencies.
+ * Move to npm (from yarn).
+
 # v1.4.2 (September 16, 2024)
  * Upgrade actions to non-deprecated versions.
  * Treat socket not found as info (not warning) as expected.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssh-socket-action",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssh-socket-action",
-      "version": "1.4.2",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh-socket-action",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "Setup an SSH socket with a private key.",
   "main": "index.js",
   "keywords": [],


### PR DESCRIPTION
# v1.5.0 (March 16, 2026)
 * Move action to node24.
 * Upgrade dependencies.
 * Move to npm (from yarn).
